### PR TITLE
Support hosts update in Docker

### DIFF
--- a/lib/vagrant-hosts/cap/sync_hosts/posix.rb
+++ b/lib/vagrant-hosts/cap/sync_hosts/posix.rb
@@ -15,7 +15,7 @@ class VagrantHosts::Cap::SyncHosts::POSIX < VagrantHosts::Cap::SyncHosts::Base
 
   def update_hosts
     upload_tmphosts
-    @machine.communicate.sudo('install -m 644 /tmp/hosts /etc/hosts')
+    @machine.communicate.sudo('cat /tmp/hosts > /etc/hosts')
   end
 
   # Generates content appropriate for a linux hosts file


### PR DESCRIPTION
Docker bind mounts /etc/hosts, so it is not possible to use install
command (as it tries to unlink the existing file). This commit simply
uses redirection to overwrite the file which is Docker safe. No need to
set permissions as permissions are kept with redirection.